### PR TITLE
row.match multiple class warning (e.g. data.table)

### DIFF
--- a/R/row.match.R
+++ b/R/row.match.R
@@ -27,7 +27,7 @@
 #' @export
 "row.match" <-
   function(x, table, nomatch=NA){
-    if (class(table)=="matrix") table <- as.data.frame(table)
+    if ("matrix"%in%class(table)) table <- as.data.frame(table)
     if (is.null(dim(x))) x <- as.data.frame(matrix(x,nrow=1))
     cx <- do.call("paste",c(x[,,drop=FALSE],sep="\r"))
     ct <- do.call("paste",c(table[,,drop=FALSE],sep="\r"))


### PR DESCRIPTION
Fixes `row.match` throwing a warning when used on a data.table.
```
> prodlim::row.match(X,DT)
[1] 18
Warning message:
In if (class(table) == "matrix") table <- as.data.frame(table) :
  the condition has length > 1 and only the first element will be used
> class(DT)
[1] "data.table" "data.frame"
```